### PR TITLE
fix computation of circles intersection

### DIFF
--- a/robotics_toolbox/utils/geometry_utils.py
+++ b/robotics_toolbox/utils/geometry_utils.py
@@ -29,12 +29,36 @@ def circle_circle_intersection(
     Returns empty array if there is no solution, two solutions otherwise. If there
     are infinite number of solutions, select two (almost) randomly.
     """
-    ca = Point(c0).buffer(r0, quad_segs=64).boundary
-    cb = Point(c1).buffer(r1, quad_segs=64).boundary
-    ints = ca.intersection(cb)
-    if ints.is_empty:
+    c0 = np.asarray(c0)
+    c1 = np.asarray(c1)
+    d = np.linalg.norm(c1 - c0)
+    if r0 + r1 < d < np.abs(r0 - r1):
         return []
-    return [g.coords[0] for g in islice(ints.geoms, 2)]
+
+    if np.isclose(d, 0) and np.isclose(r0, r1):
+        return [
+            c0 + [r0 * np.cos(a), r0 * np.sin(a)]
+            for a in np.random.uniform(-np.pi, np.pi, 2)
+        ]
+    a = (r0**2 - r1**2 + d**2) / (2 * d)
+    h = np.sqrt(r0**2 - a**2)
+    x0, y0 = c0
+    x1, y1 = c1
+    x2 = x0 + a * (x1 - x0) / d
+    y2 = y0 + a * (y1 - y0) / d
+    x3 = x2 + h * (y1 - y0) / d
+    y3 = y2 - h * (x1 - x0) / d
+    x4 = x2 - h * (y1 - y0) / d
+    y4 = y2 + h * (x1 - x0) / d
+
+    return [np.array([x3, y3]), np.array([x4, y4])]
+
+    # ca = Point(c0).buffer(r0, quad_segs=10000).boundary
+    # cb = Point(c1).buffer(r1, quad_segs=10000).boundary
+    # ints = ca.intersection(cb)
+    # if ints.is_empty:
+    #     return []
+    # return [g.coords[0] for g in islice(ints.geoms, 2)]
 
 
 def circle_line_intersection(c0: ArrayLike, r0: float, a1: ArrayLike, b1: ArrayLike):

--- a/robotics_toolbox/utils/geometry_utils.py
+++ b/robotics_toolbox/utils/geometry_utils.py
@@ -5,7 +5,6 @@
 #     Author: Vladimir Petrik <vladimir.petrik@cvut.cz>
 #
 from __future__ import annotations
-from itertools import islice
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -52,13 +51,6 @@ def circle_circle_intersection(
     y4 = y2 + h * (x1 - x0) / d
 
     return [np.array([x3, y3]), np.array([x4, y4])]
-
-    # ca = Point(c0).buffer(r0, quad_segs=10000).boundary
-    # cb = Point(c1).buffer(r1, quad_segs=10000).boundary
-    # ints = ca.intersection(cb)
-    # if ints.is_empty:
-    #     return []
-    # return [g.coords[0] for g in islice(ints.geoms, 2)]
 
 
 def circle_line_intersection(c0: ArrayLike, r0: float, a1: ArrayLike, b1: ArrayLike):

--- a/tests/test_geometry_utils.py
+++ b/tests/test_geometry_utils.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+#
+# Copyright (c) CTU -- All Rights Reserved
+# Created on: 2023-10-19
+#     Author: Vladimir Petrik <vladimir.petrik@cvut.cz>
+#
+import unittest
+import numpy as np
+from robotics_toolbox.utils import circle_circle_intersection
+
+
+class TestGeometryUtils(unittest.TestCase):
+    def test_circ_circ_intersection(self):
+        ints = circle_circle_intersection([0, 0], 1, [1, 0], 1)
+        self.assertEqual(len(ints), 2)
+        (ax, ay), (bx, by) = ints
+        if by > ay:
+            ay, by = by, ay
+        self.assertAlmostEqual(ax, 0.5)
+        self.assertAlmostEqual(ay, np.sqrt(1 - 0.5**2))
+        self.assertAlmostEqual(bx, 0.5)
+        self.assertAlmostEqual(by, -np.sqrt(1 - 0.5**2))
+
+        ints = circle_circle_intersection([0, 0], 1, [2, 0], 1)
+        self.assertEqual(len(ints), 2)
+        (ax, ay), (bx, by) = ints
+        self.assertAlmostEqual(ax, 1.0)
+        self.assertAlmostEqual(ay, 0.0)
+        self.assertAlmostEqual(bx, 1.0)
+        self.assertAlmostEqual(by, 0.0)
+
+        ints = circle_circle_intersection([0, 0], 1, [0, 0], 1)
+        self.assertEqual(len(ints), 2)
+        a, b = ints
+        self.assertAlmostEqual(np.linalg.norm(a), 1.0)
+        self.assertAlmostEqual(np.linalg.norm(b), 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
There is a numerical issue with the old computation of circle-circle intersection; this PR computes it appropriately and tests it. If you are observing a small numerical error in IK computation, you can either increase the number of points that approximate circle (i.e., quad_segs=1024, instead of 64), or you can copy the updated computation from this PR.
However, do not update tests from this PR in your BRUTE submission.